### PR TITLE
change isOn and isOff promise based

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Basic volume API's:
 <Promise> onkyo.volDown()           // volume -1, resolves when ready
 <Promise> onkyo.setVolume(<volume>) // volume between 0-100, resolves when ready
 <Promise> onkyo.getVolume()         // resolves current volume
-<boolean> onkyo.isOn()              // get cached power state. Returns undefined if state is unknown
-<boolean> onkyo.isOff()             // get cached power state. Returns undefined if state is unknown
+<Promise> onkyo.isOn()              // resolves true if powers on
+<Promise> onkyo.isOff()             // resolves false if powers off
 ```
 
 Onkyo instance generates public API's based on [onkyo.commands.js](lib/onkyo.commands.js) -file and contains following Promise API's:

--- a/lib/Onkyo.js
+++ b/lib/Onkyo.js
@@ -605,14 +605,12 @@ class Onkyo extends EventEmitter {
       });
   }
   isOn() {
-    return _.get(this.deviceState, 'PWR');
+    return this.pwrState()
+      .then(({PWR}) => PWR);
   }
   isOff() {
-    const on = _.get(this.deviceState, 'PWR');
-    if (_.isUndefined(on)) {
-      return on;
-    }
-    return !on;
+    return this.pwrState()
+      .then(({PWR}) => PWR === false);
   }
   volumeState() {
     return this.sendCommand('AUDIO', 'STATUS_VOL');

--- a/test/onkyo.js
+++ b/test/onkyo.js
@@ -164,8 +164,6 @@ describe('Onkyo', function () {
       })
       .then(() => {
         expect(socket.write.callCount).to.be.equal(1);
-        expect(onkyo.isOn()).to.be.true;
-        expect(onkyo.isOff()).to.be.false;
       });
   });
   describe('api', function () {
@@ -214,7 +212,11 @@ describe('Onkyo', function () {
         () => onkyo._parseClientPacket('SLI02', pypass), // Game
         () => onkyo._parseClientPacket('MVL01', pypass), // VOL 1
         () => onkyo._parseClientPacket('AMT00', pypass), // unmute
-        () => onkyo._parseClientPacket('LMD01', pypass) // sound mode direct
+        () => onkyo._parseClientPacket('LMD01', pypass), // sound mode direct
+        () => onkyo._parseClientPacket('PWR01', pypass), // POWER on
+        () => onkyo._parseClientPacket('PWR01', pypass), // POWER on
+        () => onkyo._parseClientPacket('PWR00', pypass), // POWER off
+        () => onkyo._parseClientPacket('PWR00', pypass) // POWER off
       ];
       _.each(callFakes, (callFake, index) => {
         onkyo._sendISCPpacket.onCall(index).callsFake(callFake);
@@ -225,7 +227,22 @@ describe('Onkyo', function () {
             PWR: true, SLI: 'GAME', MVL: 1, AMT: false, LMD: 'DIRECT'
           };
           expect(states).to.be.deep.equal(shouldBe);
-          expect(onkyo.isOn()).to.be.true;
+          return onkyo.isOn();
+        })
+        .then((on) => {
+          expect(on).to.be.true;
+          return onkyo.isOff();
+        })
+        .then((off) => {
+          expect(off).to.be.false;
+          return onkyo.isOn();
+        })
+        .then((on) => {
+          expect(on).to.be.false;
+          return onkyo.isOff();
+        })
+        .then((off) => {
+          expect(off).to.be.true;
         });
     });
     // @TODO more test..


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Switch `isOn()` and `isOff()` API's promise based because earlier results based on cache - which might not  be up-to-date. Promise now request real status from device and resolves boolean.

## Related PR/Issues
Fix #27 

## Todos
- [x] Tests
- [x] Documentation