### PR TITLE
ensure 2 digits for volumeHex

### DIFF
--- a/lib/Onkyo.js
+++ b/lib/Onkyo.js
@@ -682,7 +682,7 @@ class Onkyo extends EventEmitter {
   setVolume(volume) {
     invariant(_.isInteger(volume), 'volume should be an integer');
     invariant(volume >= 0 && volume <= 100, 'volume should be between 0-100');
-    const volumeHex = volume.toString(16).toUpperCase();
+    const volumeHex = volume.toString(16).toUpperCase().padStart(2, '0');
     return this.sendRawCommand(`MVL${volumeHex}`)
       .then(vol => parseInt(vol, 16));
   }


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
For volume level below 16, the `MVL` command currently only has 1 digit. This doesn't work (for my ONKYO receivers). It has to be 2 digits.

## Steps to Test or Reproduce
Try setting the volume below 16 before and after the fix.
