### PR TITLE
Add center volume commands + fix return for setVolume

### DIFF
--- a/lib/Onkyo.js
+++ b/lib/Onkyo.js
@@ -690,7 +690,7 @@ class Onkyo extends EventEmitter {
     invariant(volume >= 0 && volume <= 100, 'volume should be between 0-100');
     const volumeHex = volume.toString(16).toUpperCase();
     return this.sendRawCommand(`MVL${volumeHex}`)
-      .then(vol => parseInt(vol, 16));
+      .then(({MVL}) => MVL);
   }
   getCenterVolume() {
     return this.sendCommand('AUDIO', 'STATUS_CTL')

--- a/lib/Onkyo.js
+++ b/lib/Onkyo.js
@@ -692,6 +692,17 @@ class Onkyo extends EventEmitter {
     return this.sendRawCommand(`MVL${volumeHex}`)
       .then(vol => parseInt(vol, 16));
   }
+  getCenterVolume() {
+    return this.sendCommand('AUDIO', 'STATUS_CTL')
+      .then(({CTL}) => CTL);
+  }
+  setCenterVolume(volume) {
+    invariant(_.isInteger(volume), 'volume should be an integer');
+    invariant(volume >= -12 && volume <= 12, 'volume should be between -12 and 12');
+    const volumeHex = ((volume > 0 ? '+' : '') + volume.toString(16).toUpperCase()).padStart(2, '0');
+    return this.sendRawCommand(`CTL${volumeHex}`)
+      .then(({CTL}) => CTL);
+  }
   setSource(source) {
     return this.sendCommand('SOURCE_SELECT', source);
   }

--- a/lib/Onkyo.js
+++ b/lib/Onkyo.js
@@ -165,6 +165,12 @@ class Onkyo extends EventEmitter {
         this.logger.debug(`masterVolume: ${MVL}`);
         return Promise.resolve({group, data: {MVL}});
       }
+      case 'CTL': {
+        const CTL = Onkyo._parseInt(command, 16);
+        this.deviceState.CTL = CTL;
+        this.logger.debug(`centerVolume: ${CTL}`);
+        return Promise.resolve({group, data: {CTL}});
+      }
       case 'PWR': {
         const PWR = Onkyo._parseBool(command);
         this.deviceState.PWR = PWR; // power state

--- a/lib/onkyo.commands.js
+++ b/lib/onkyo.commands.js
@@ -28,7 +28,13 @@ const AUDIO =
     Volume: 'MVLQSTN',
     VOL_QSTN: 'MVLQSTN',
     STATUS_VOL: 'MVLQSTN',
-    STATUS_MUTE: 'AMTQSTN'
+    STATUS_MUTE: 'AMTQSTN',
+    CTL_UP: 'CTLUP',
+    'Center Up': 'CTLUP',
+    CTL_DOWN: 'CTLDOWN',
+    'Center Down': 'CTLDOWN',
+    CTL_QSTN: 'CTLQSTN',
+    STATUS_CTL: 'CTLQSTN'
   };
 
 // Cinema Filter

--- a/test/onkyo.js
+++ b/test/onkyo.js
@@ -186,7 +186,7 @@ describe('Onkyo', function () {
       it('pass', function () {
         const vol = 50;
         onkyo._sendISCPpacket.callsFake(() => {
-          onkyo.emit('MVL', vol.toString(16));
+          onkyo._parseClientPacket(`MVL${vol.toString(16)}`, pypass);
         });
         return onkyo.setVolume(vol)
           .then((volume) => {

--- a/test/onkyo.js
+++ b/test/onkyo.js
@@ -206,6 +206,36 @@ describe('Onkyo', function () {
           });
       });
     });
+    describe('setCenterVolume', function () {
+      it('throws when invalid input', function () {
+        expect(() => onkyo.setCenterVolume('')).to.throw(Error);
+        expect(() => onkyo.setCenterVolume(0.1)).to.throw(Error);
+        expect(() => onkyo.setCenterVolume(-13)).to.throw(Error);
+        expect(() => onkyo.setCenterVolume(13)).to.throw(Error);
+      });
+      it('pass', function () {
+        const vol = 6;
+        onkyo._sendISCPpacket.callsFake(() => {
+          onkyo._parseClientPacket(`CTL+${vol.toString(16)}`, pypass);
+        });
+        return onkyo.setCenterVolume(vol)
+          .then((volume) => {
+            expect(volume).to.be.eql(vol);
+          });
+      });
+    });
+    describe('getCenterVolume', function () {
+      it('pass', function () {
+        const vol = 10;
+        onkyo._sendISCPpacket.callsFake(() => {
+          onkyo._parseClientPacket(`CTL+${vol.toString(16)}`, pypass);
+        });
+        return onkyo.getCenterVolume()
+          .then((volume) => {
+            expect(volume).to.be.eql(vol);
+          });
+      });
+    });
     it('getDeviceState', function () {
       const callFakes = [
         () => onkyo._parseClientPacket('PWR01', pypass), // POWER on


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Add CTL commands and add/setCernterVolume methods.

Center volume can (on my ONKYO receivers) be between -12 and +12, so the command can be `CTL-C` to `CTL-1`, `CTL00`and `CTL+1` to `CTL+C`.

**FIX** While implementing and manual testing I saw, that the return value of `setVolume` was `NaN`. It seems, that `setVolume` wanted the data to be only the volume, but `_parseMsg` returns `{MVL}` as data, not `MVL` (which is correctly processed by `getVolume`).

## Steps to Test or Reproduce
Try setting center volume with e.g. `onkyo.sendRawCommand('CTL00')`